### PR TITLE
Remove trailling comma in the artist mp3 tag

### DIFF
--- a/Savify/Savify.Core/SpotifyAgent.cs
+++ b/Savify/Savify.Core/SpotifyAgent.cs
@@ -95,7 +95,10 @@ namespace Savify.Core
             foreach (PlaylistTrack track in playlist.Items)
             {
                 string artists = "";
-                track.Track.Artists.ForEach(artist => artists += artist.Name + ",");
+                foreach (var artist in track.Track.Artists)
+                {
+                    artists += (artists.Length > 0 ? ", " : "") + artist.Name;
+                }
                 track.Track.ExternUrls.TryGetValue("spotify", out string link);
 
                 tracks.Add(new Track()
@@ -122,7 +125,10 @@ namespace Savify.Core
             FullTrack track = _spotify.GetTrack(trackId);
 
             string artists = "";
-            track.Artists.ForEach(artist => artists += artist.Name + ",");
+            foreach (var artist in track.Artists)
+            {
+                artists += (artists.Length > 0 ? ", " : "") + artist.Name;
+            }
 
             return new Track()
             {


### PR DESCRIPTION
When a track contains multiple contributed artists, there is a comma at the end of the string.

The fix is to not add a comma after the artist name each time an artist name is added to the string.

I choose to add the symbol before the artist name if it is not the first artist added to the string.

```C#
track.Track.Artists.ForEach(artist => artists += artist.Name + ",");
```
is replaced by
```C#
track.Track.Artists.ForEach(artist => artists += artist.Name + ",");
foreach (var artist in track.Track.Artists)
{
    artists += (artists.Length > 0 ? ", " : "") + artist.Name;
}
```